### PR TITLE
Make listen\resync events tasks optional in events reader service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ solana = ["dep:solana-client", "dep:solana-sdk", "dep:solana-transaction-status"
 anchor = ["solana", "dep:anchor-lang", "dep:base64"]
 storage = ["solana"]
 rocksdb = ["dep:rocksdb", "dep:bincode"]
-event-reader = ["storage", "dep:futures", "dep:thiserror", "dep:non-empty-vec"]
+event-reader = ["storage", "dep:futures", "dep:thiserror", "dep:non-empty-vec", "dep:derive_builder"]
 
 [dependencies]
 anyhow = "1.0.71"
@@ -29,6 +29,7 @@ async-trait = "0.1.68"
 base64 = { version = "0.13.0", optional = true }
 bincode = { version = "1.3.3", optional = true }
 bs58 = "0.5.0"
+derive_builder = { version = "0.12.0", optional = true }
 futures = { version = "0.3", optional = true }
 lazy_static = "1.4.0"
 non-empty-vec = { version = "0.2.3", optional = true }


### PR DESCRIPTION
This commit adds a new flag to enable/disable resync functionality and an option for a `PubsubClient` to the `event_reader_service`. The change also updates the listen_events function to use the new pubsub_client option.

Close #1
